### PR TITLE
Update admin.js to show non-existent links on the sidebar.

### DIFF
--- a/public/bsbmd/js/admin.js
+++ b/public/bsbmd/js/admin.js
@@ -124,8 +124,12 @@ $.AdminBSB.leftSideBar = {
 
             //Scroll active menu item when page load, if option set = true
             if ($.AdminBSB.options.leftSideBar.scrollActiveItemWhenPageLoad) {
+                if ($('.menu .list li.active')[0]) {
                 var activeItemOffsetTop = $('.menu .list li.active')[0].offsetTop
-                if (activeItemOffsetTop > 150) $el.slimscroll({ scrollTo: activeItemOffsetTop + 'px' });
+                    if (activeItemOffsetTop > 150) {
+                        $el.slimscroll({ scrollTo: activeItemOffsetTop + 'px' });
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
When we create a new route without adding it through the sidebar.blade.php the admin.js return an error and the page keeps displaying a blank content and the loading info.